### PR TITLE
Fix typo in neutron namespace drain role

### DIFF
--- a/roles/neutron_namespace_drain/tasks/add-new-l3.yml
+++ b/roles/neutron_namespace_drain/tasks/add-new-l3.yml
@@ -37,6 +37,6 @@
   delegate_to: "{{ neutron_namespace_play_host }}"
   vars:
     ansible_host: "{{ hostvars[neutron_namespace_play_host].ansible_host }}"
-    l3_add_diff: "{{ l3_id.stdout_lines | difference([l3_src_id]) | difference(item.stdout_lines) }}"
+    l3_add_diff: "{{ l3_id.stdout_lines | difference([src_l3_id]) | difference(item.stdout_lines) }}"
     l3_add: "{{ l3_add_diff[:1] | first }}"
   when: l3_add_diff | length > 0

--- a/roles/neutron_namespace_drain/tasks/drain-dhcp.yml
+++ b/roles/neutron_namespace_drain/tasks/drain-dhcp.yml
@@ -54,7 +54,7 @@
 
     - name: Fail if DHCP agent still attached
       ansible.builtin.fail:
-        msg: a DHCP agent is still attached to "{{ l3_src_id }}"
+        msg: a DHCP agent is still attached to "{{ src_l3_id }}"
       when: agent_status.stdout | length > 0
 
     - name: Reset retry count after success


### PR DESCRIPTION
Fixes playbook failing with
```
TASK [stackhpc.openstack_ops.neutron_namespace_drain : Add router to agent] ******************************************************************************************************************
Wednesday 14 January 2026  13:02:03 +0000 (0:08:10.080)       0:08:24.135 ***** 
fatal: [localhost -> {{ neutron_namespace_play_host }}]: FAILED! => 
  msg: |-
    The conditional check 'l3_add_diff | length > 0' failed. The error was: error while evaluating conditional (l3_add_diff | length > 0): {{ l3_id.stdout_lines | difference([l3_src_id]) | d
ifference(item.stdout_lines) }}: 'l3_src_id' is undefined. 'l3_src_id' is undefined. {{ l3_id.stdout_lines | difference([l3_src_id]) | difference(item.stdout_lines) }}: 'l3_src_id' is undefi
ned. 'l3_src_id' is undefined
  
    The error appears to be in '/stack/kayobe-automation-env/src/kayobe-config/etc/kayobe/ansible/collections/ansible_collections/stackhpc/openstack_ops/roles/neutron_namespace_drain/tasks/a
dd-new-l3.yml': line 28, column 3, but may
    be elsewhere in the file depending on the exact syntax problem.
  
    The offending line appears to be:
  
  
    - name: Add router to agent
      ^ here
```